### PR TITLE
Specified minio image tag as commit date

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 # starts 4 docker containers running minio server instances. Each minio server's web interface will be accessible on the host at port 9001 through 9004.
 services:
   minio1:
-    image: minio/minio
+    image: minio/minio:RELEASE.2018-02-09T22-40-05Z
     volumes:
       - data1:/data
     ports:
@@ -15,7 +15,7 @@ services:
     command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data 
     
   minio2:
-    image: minio/minio
+    image: minio/minio:RELEASE.2018-02-09T22-40-05Z
     volumes:
       - data2:/data
     ports:
@@ -28,7 +28,7 @@ services:
     command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data 
     
   minio3:
-    image: minio/minio
+    image: minio/minio:RELEASE.2018-02-09T22-40-05Z
     volumes:
       - data3:/data
     ports:
@@ -41,7 +41,7 @@ services:
     command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data 
     
   minio4:
-    image: minio/minio
+    image: minio/minio:RELEASE.2018-02-09T22-40-05Z
     volumes:
       - data4:/data
     ports:


### PR DESCRIPTION
It doesn't work with the latest image, so I've specified the older version first.

I would like to improve it so that it can work with current image.